### PR TITLE
Upgrade Tests & Benchmarks projects to .NET 7

### DIFF
--- a/tests/Shortcodes.Benchmarks/Shortcodes.Benchmarks.csproj
+++ b/tests/Shortcodes.Benchmarks/Shortcodes.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
 
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Shortcodes.Tests/Shortcodes.Tests.csproj
+++ b/tests/Shortcodes.Tests/Shortcodes.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
While .NET 5.0 is out of support it's good to upgrade